### PR TITLE
add support for de/json of either + maybe types

### DIFF
--- a/serjson.kk
+++ b/serjson.kk
@@ -27,6 +27,7 @@ module serjson
 
 import std/core/either
 import std/core/list
+import std/core/string
 import std/core/undiv
 import std/text/parse 
 
@@ -46,9 +47,27 @@ pub type value
 fun object-entry/show'(e: object-entry) : div string
   "\"" ++ e.key ++ "\": " ++ e.value.show'
 
+// quote a char for JSON
+fun quote-char(c: char): string
+  match c
+    '"' -> "\\\""
+    '\\' -> "\\\\"
+    // '/' -> "\\/"
+    // 'b' -> "\\b"
+    // 'f' -> "\\f"
+    '\n' -> "\\n"
+    '\r' -> "\\r"
+    '\t' -> "\\t"
+    // 'u' -> "\\u"
+    _ -> c.string
+
+// quote " and \ characters in a string
+fun quote-string(s: string): string
+  s.list.map(quote-char).join
+
 fun value/show'(v: value) : div string
   match v
-    String(s) -> "\"" ++ s ++ "\""
+    String(s) -> "\"" ++ s.quote-string ++ "\""
     Int(i) -> i.show
     Bool(b) -> if b then "true" else "false"
     Null -> "null"
@@ -115,9 +134,9 @@ fun is-json-string-char(c)
   && c != '\\'
   && !is-control(c)
 
-fun json-string-chars()
+fun json-string-char()
   parse/(||)(
-    {chars-are("json-string-chars", is-json-string-char).string}, 
+    {char-is("json-string-chars", is-json-string-char).string}, 
     {quoted-char().string}
   )
 
@@ -126,7 +145,7 @@ fun double-quote()
 
 fun json-string()
   double-quote()
-  val str = many(json-string-chars).join
+  val str = many(json-string-char).join
   double-quote()
   str
 

--- a/serjson.kk
+++ b/serjson.kk
@@ -13,10 +13,10 @@ module serjson
 //
 // It can serialize and deserialize nested structures to/from JSON with the 
 // provision of two functions:
-//   valuefn<t> = (t) -> div serjson/value
+//   vfn<t> = (t) -> div serjson/value
 //   pfn<t> = (serjson/value) -> <div,parse> t
 // 
-// valuefn takes a t and returns a serjson/value, while pfn takes a serjson/value
+// vfn takes a t and returns a serjson/value, while pfn takes a serjson/value
 // and returns a t (or fails the parse)
 //
 // given those functions, provided as implicit values, a value can be serialized
@@ -211,52 +211,79 @@ pub fun parse-value(s: string)
 
 // functions to serialize and deserialize values
 
-pub alias pfn<t> = (serjson/value) -> parse t
-pub alias valuefn<t> = (t) -> total serjson/value
+pub alias vfn<t> = (t) -> total value
+pub alias pfn<t> = (value) -> parse t
+// need effect-polymorphic versions to allow dismissal of the inferred div 
+// effect in recursive HOF cases
+pub alias pvfn<t,e> = (t) -> e value
+pub alias ppfn<t,e> = (value) -> <parse|e> t
 
-pub fun string/valuefn(s: string): total serjson/value
+pub fun string/vfn(s: string): total serjson/value
   String(s)
 pub fun string/pfn(v: serjson/value): parse string
   match v
     String(s) -> s
     _ -> fail("expected string")
 
-pub fun int/valuefn(i: int): total serjson/value
+pub fun int/vfn(i: int): total serjson/value
   Int(i)
 pub fun int/pfn(v: serjson/value): parse int
   match v
     Int(i) -> i
     _ -> fail("expected int")
 
-pub fun bool/valuefn(b: bool): total serjson/value
+pub fun bool/vfn(b: bool): total serjson/value
   Bool(b)
 pub fun bool/pfn(v: serjson/value): parse bool
   match v
     Bool(b) -> b
     _ -> fail("expected bool")
 
-pub fun null/valuefn(): total serjson/value
+pub fun null/vfn(): total serjson/value
   Null
 pub fun null/pfn(v: serjson/value): parse ()
   match v
     Null -> ()
     _ -> fail("expected null")
 
-pub fun list/make-valuefn<t>(elvfn: valuefn<t>): valuefn<list<t>>
+pub fun list/make-vfn<t,e>(elvfn: pvfn<t,e>): pvfn<list<t>,e>
   fn(l)
     Array(l.map(elvfn))
-
-pub fun list/make-pfn<t>(elpfn: pfn<t>): pfn<list<t>>
+pub fun list/make-pfn<t>(elpfn: ppfn<t,e>): ppfn<list<t>,e>
   fn(v: serjson/value)
     match v
       Array(a) -> a.map(elpfn)
       _ -> fail("expected array")
+
+pub fun maybe/make-vfn<t>(vfn: pvfn<t,e>): pvfn<maybe<t>,e>
+  fn(m)
+    match m
+      Just(v) -> Object([Object-entry("Just", vfn(v))])
+      Nothing -> Object([Object-entry("Nothing", Null)])
+pub fun maybe/make-pfn<t>(pfn: ppfn<t,e>): ppfn<maybe<t>,e>
+  fn(v: serjson/value)
+    match v
+      Object([Object-entry("Just", v)]) -> Just(pfn(v))
+      Object([Object-entry("Nothing", Null)]) -> Nothing
+      _ -> fail("expected maybe")
+
+pub fun either/make-vfn<t,u>(lvfn: pvfn<t,e>, rvfn: pvfn<u,e>): pvfn<either<t,u>,e>
+  fn(e)
+    match e
+      Left(v) -> Object([Object-entry("Left", lvfn(v))])  
+      Right(v) -> Object([Object-entry("Right", rvfn(v))])
+pub fun either/make-pfn<t,u>(lpfn: ppfn<t,e>, rpfn: ppfn<u,e>): ppfn<either<t,u>,e>
+  fn(v: serjson/value)
+    match v
+      Object([Object-entry("Left", v)]) -> Left(lpfn(v))
+      Object([Object-entry("Right", v)]) -> Right(rpfn(v))
+      _ -> fail("expected either")
  
 
 // convert values from and to JSON
 
-pub fun json<t>(t: t, ?valuefn: valuefn<t>): total string
-  ?valuefn(t).show
+pub fun json<t>(t: t, ?vfn: vfn<t>): total string
+  ?vfn(t).show
 
 pub fun dejson<t>(s: string, ?pfn: pfn<t>): total either<string,t>
   s.slice.parse({serjson/pvalue().?pfn}).either

--- a/serjson_test.kk
+++ b/serjson_test.kk
@@ -187,6 +187,20 @@ fun either-either-int/(==)(a: either<string,either<string,int>>, b: either<strin
 
 // examples
 
+pub fun example-double-encode-string()
+  val sj = "foo".json
+  sj.println
+  val sjj = sj.json
+  sjj.println
+  val either-sj' = sjj.dejson(?pfn=string/pfn)
+  match either-sj'
+    Right(sj') ->       
+      val either-s' = sj'.dejson(?pfn=string/pfn)
+      match either-s'
+        Right(s') -> s'.println
+        Left(e) -> e.println
+    Left(e) -> e.println
+
 pub fun example-value-parse()
   "{\"foo\": [1,\"two\",true,{\"bar\": 200}]}".parse-value.show
 

--- a/serjson_test.kk
+++ b/serjson_test.kk
@@ -1,5 +1,6 @@
 module serjson_test
 
+import std/core/maybe
 import std/text/parse 
 import std/test/test
 import serjson
@@ -36,9 +37,9 @@ fun either/list/(==)(a: either<string,list<int>>, b: either<string,list<int>>): 
     (Right(aa),Right(bb)) -> aa == bb
     _ -> False
 
-// valuefn and pfn for thing and stuff
+// vfn and pfn for thing and stuff
 
-fun thing/valuefn(t: thing)
+fun thing/vfn(t: thing)
   Object([
     Object-entry("name", String(t.name))
   ])
@@ -50,11 +51,11 @@ fun thing/pfn(v: value)
         Thing(name)
     _ -> fail("thing: bad json")
 
-fun stuff/valuefn(s: stuff)
+fun stuff/vfn(s: stuff)
   Object([
     Object-entry("foo", Int(s.foo)),
     Object-entry("bar", String(s.bar)),
-    Object-entry("thing", thing/valuefn(s.thing))
+    Object-entry("thing", thing/vfn(s.thing))
   ])
 
 pub fun stuff/pfn(v: value)
@@ -68,7 +69,7 @@ pub fun stuff/pfn(v: value)
     _ -> fail("stuff: bad json")
 
 fun stuff/show(s: stuff)
-  s.json(?valuefn=stuff/valuefn).show
+  s.json(?vfn=stuff/vfn).show
 
 // tests
 
@@ -123,7 +124,7 @@ pub fun test-serjson()
   basic/scope("nested roundtrip")
     scoped/test("stuff-roundtrip")
       val s = Stuff(10, "blah", Thing("graagh"))
-      val json = s.json(?valuefn=stuff/valuefn)
+      val json = s.json(?vfn=stuff/vfn)
 
       val reparsed: either<string,stuff> = json.dejson
 
@@ -133,16 +134,56 @@ pub fun test-serjson()
   basic/scope("lists")
     scoped/test("empty-list")
       val s = []
-      val json = s.json(?valuefn=list/make-valuefn(int/valuefn))
+      val json = s.json(?vfn=list/make-vfn(int/vfn))
       val reparsed: either<string,list<int>> = json.dejson(?pfn=list/make-pfn(int/pfn))
       val expectation = Right(s)
       expect(expectation, fn () reparsed)
     scoped/test("list of ints")
       val s = [1,2,3]
-      val json = s.json(?valuefn=list/make-valuefn(int/valuefn))
+      val json = s.json(?vfn=list/make-vfn(int/vfn))
       val reparsed: either<string,list<int>> = json.dejson(?pfn=list/make-pfn(int/pfn))
       val expectation = Right(s)
       expect(expectation, fn () reparsed)
+
+  basic/scope("maybes")
+    scoped/test("nothing")
+      val s = Nothing
+      val json = s.json(?vfn=maybe/make-vfn(int/vfn))
+      val reparsed: either<string,maybe<int>> = json.dejson(?pfn=maybe/make-pfn(int/pfn))
+      val expectation = Right(s)
+      expect(expectation, fn () reparsed, ?(==)=either-maybe-int/(==))
+    scoped/test("just")
+      val s = Just(10)
+      val json = s.json(?vfn=maybe/make-vfn(int/vfn))
+      val reparsed: either<string,maybe<int>> = json.dejson(?pfn=maybe/make-pfn(int/pfn))
+      val expectation = Right(s)
+      expect(expectation, fn () reparsed)
+
+  basic/scope("eithers")
+    scoped/test("left")
+      val s = Left("foo")
+      val json = s.json(?vfn=either/make-vfn(string/vfn, int/vfn))
+      val reparsed: either<string,either<string,int>> = json.dejson(?pfn=either/make-pfn(string/pfn, int/pfn))
+      val expectation = Right(s)
+      expect(expectation, fn () reparsed)
+    scoped/test("right")
+      val s = Right(10)
+      val json = s.json(?vfn=either/make-vfn(string/vfn, int/vfn))
+      val reparsed: either<string,either<string,int>> = json.dejson(?pfn=either/make-pfn(string/pfn, int/pfn))
+      val expectation = Right(s)
+      expect(expectation, fn () reparsed)
+
+fun either-maybe-int/(==)(a: either<string,maybe<int>>, b: either<string,maybe<int>>): bool
+  match (a,b)
+    (Right(Just(aa)),Right(Just(bb))) -> aa == bb
+    (Right(Nothing),Right(Nothing)) -> True
+    _ -> False
+
+fun either-either-int/(==)(a: either<string,either<string,int>>, b: either<string,either<string,int>>): bool
+  match (a,b)
+    (Right(Left(aa)),Right(Left(bb))) -> aa == bb
+    (Right(Right(aa)),Right(Right(bb))) -> aa == bb
+    _ -> False
 
 // examples
 


### PR DESCRIPTION
- adds some support for de/json of `either` and `maybe` types
- makes fn naming a bit more uniform
- adds some effect-polymorphic signatures to help with dismissal of `div` effects in recursive parsers/encoders for types using a HOF `vfn` / `pfn` like the `either`, `maybe`, and `list` parsers/encoders
- fixes a double-encoded string bug (by properly quoting strings when encoding) 